### PR TITLE
Allow to  create a new reference to existing account for payments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = "Python SDK for AltScore"
 
 setup(
     name="altscore",
-    version="0.1.133",
+    version="0.1.134",
     description="Python SDK for AltScore. It provides a simple interface to the AltScore API.",
     package_dir={"": "src"},
     packages=find_packages(where="src"),

--- a/src/altscore/cms/model/payment_accounts.py
+++ b/src/altscore/cms/model/payment_accounts.py
@@ -51,3 +51,12 @@ class CreatePaymentAccountDTO(BaseModel):
         populate_by_name = True
         allow_population_by_field_name = True
         populate_by_alias = True
+
+
+class CreatePaymentReferenceDTO(BaseModel):
+    provider: str = Field(alias="provider", default=None)
+
+    class Config:
+        populate_by_name = True
+        allow_population_by_field_name = True
+        populate_by_alias = True


### PR DESCRIPTION
Description:
When a new provider is integrated to Payment service must have to create a reference for that provider also, when a reference in cancelled need be create a new one.

This PR allow create a new reference for specific provider or for all provider enable for the partner/tenant.