### PR TITLE
Delete workflow schedules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = "Python SDK for AltScore"
 
 setup(
     name="altscore",
-    version="0.1.182",
+    version="0.1.183",
     description="Python SDK for AltScore. It provides a simple interface to the AltScore API.",
     package_dir={"": "src"},
     packages=find_packages(where="src"),

--- a/src/altscore/borrower_central/__init__.py
+++ b/src/altscore/borrower_central/__init__.py
@@ -21,7 +21,7 @@ from altscore.borrower_central.model.forms import FormsAsyncModule, FormsSyncMod
 from altscore.borrower_central.model.policy_alerts import AlertsAsyncModule, AlertsSyncModule
 from altscore.borrower_central.model.policy_rules import RulesAsyncModule, RulesSyncModule
 from altscore.borrower_central.model.integrations.sat import SatIntegrationAsyncModule, SatIntegrationSyncModule
-from altscore.borrower_central.model.integrations.sri import SriIntegrationAsyncModule, SritIntegrationSyncModule
+from altscore.borrower_central.model.integrations.sri import SriIntegrationAsyncModule, SriIntegrationSyncModule
 from altscore.borrower_central.model.automations import AutomationsAsyncModule, AutomationsSyncModule
 from altscore.borrower_central.model.stages import StagesAsyncModule, StagesSyncModule
 from altscore.borrower_central.model.risk_ratings import RiskRatingsAsyncModule, RiskRatingsSyncModule
@@ -103,7 +103,7 @@ class BorrowerCentralSync:
         self.rules = RulesSyncModule(altscore_client)
         self.policies = PolicySyncModule(altscore_client)
         self.sat_integration = SatIntegrationSyncModule(altscore_client)
-        self.sri_integration = SritIntegrationSyncModule(altscore_client)
+        self.sri_integration = SriIntegrationSyncModule(altscore_client)
         self.usecases = UsecasesSyncModule(altscore_client)
         self.kpis = KpisSyncModule(altscore_client)
         self.steps = StepsSyncModule(altscore_client)

--- a/src/altscore/borrower_central/model/integrations/sri.py
+++ b/src/altscore/borrower_central/model/integrations/sri.py
@@ -76,7 +76,7 @@ class SriIntegrationAsyncModule:
 
         async with httpx.Client(base_url=self.base_url) as client:
             response = client.post(
-                "/v1/integrations/sri/credentials/check",
+                "/v1/integrations/sri/credentials",
                 json=payload,
                 headers=self.build_headers()
             )
@@ -141,7 +141,7 @@ class SriIntegrationSyncModule:
             payload["additionalIdentification"] = additional_identification
         with httpx.Client(base_url=self.base_url) as client:
             response = client.post(
-                "/v1/integrations/sri/credentials/check",
+                "/v1/integrations/sri/credentials",
                 json=payload,
                 headers=self.build_headers()
             )

--- a/src/altscore/borrower_central/model/workflows.py
+++ b/src/altscore/borrower_central/model/workflows.py
@@ -116,8 +116,8 @@ class WorkflowSync(GenericSyncResource):
 
 
     @retry_on_401
-    def delete_schedules(self, delete_schedule: bool = False, delete_schedule_batch: bool = False):
-        url = f"{self.base_url}/v1/{self.resource}/{self.data.id}/delete-schedules"
+    def delete_schedules(self, schedule: bool = False, schedule_batch: bool = False):
+        url = f"{self.base_url}/v1/{self.resource}/commands/delete-schedules"
 
         with httpx.Client() as client:
             response = client.post(
@@ -125,8 +125,9 @@ class WorkflowSync(GenericSyncResource):
                 headers=self._header_builder(),
                 timeout=300,
                 json={
-                    "deleteSchedule": delete_schedule,
-                    "deleteScheduleBatch": delete_schedule_batch
+                    "workflowId": self.data.id,
+                    "schedule": schedule,
+                    "scheduleBatch": schedule_batch
                 }
             )
 
@@ -140,8 +141,8 @@ class WorkflowAsync(GenericAsyncResource):
 
 
     @retry_on_401_async
-    async def delete_schedules(self, delete_schedule: bool = False, delete_schedule_batch: bool = False):
-        url = f"{self.base_url}/v1/{self.resource}/{self.data.id}/delete-schedules"
+    async def delete_schedules(self, schedule: bool = False, schedule_batch: bool = False):
+        url = f"{self.base_url}/v1/{self.resource}/commands/delete-schedules"
 
         async with httpx.AsyncClient() as client:
             response = await client.post(
@@ -149,8 +150,9 @@ class WorkflowAsync(GenericAsyncResource):
                 headers=self._header_builder(),
                 timeout=300,
                 json={
-                    "deleteSchedule": delete_schedule,
-                    "deleteScheduleBatch": delete_schedule_batch
+                    "workflowId": self.data.id,
+                    "schedule": schedule,
+                    "scheduleBatch": schedule_batch
                 }
             )
             raise_for_status_improved(response)

--- a/src/altscore/borrower_central/model/workflows.py
+++ b/src/altscore/borrower_central/model/workflows.py
@@ -115,10 +115,45 @@ class WorkflowSync(GenericSyncResource):
         super().__init__(base_url, "workflows", header_builder, renew_token, WorkflowDataAPIDTO.parse_obj(data))
 
 
+    @retry_on_401
+    def delete_schedules(self, delete_schedule: bool = False, delete_schedule_batch: bool = False):
+        url = f"{self.base_url}/v1/{self.resource}/{self.data.id}/delete-schedules"
+
+        with httpx.Client() as client:
+            response = client.post(
+                url,
+                headers=self._header_builder(),
+                timeout=300,
+                json={
+                    "deleteSchedule": delete_schedule,
+                    "deleteScheduleBatch": delete_schedule_batch
+                }
+            )
+
+            raise_for_status_improved(response)
+
+
 class WorkflowAsync(GenericAsyncResource):
 
     def __init__(self, base_url, header_builder, renew_token, data: Dict):
         super().__init__(base_url, "workflows", header_builder, renew_token, WorkflowDataAPIDTO.parse_obj(data))
+
+
+    @retry_on_401_async
+    async def delete_schedules(self, delete_schedule: bool = False, delete_schedule_batch: bool = False):
+        url = f"{self.base_url}/v1/{self.resource}/{self.data.id}/delete-schedules"
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                url,
+                headers=self._header_builder(),
+                timeout=300,
+                json={
+                    "deleteSchedule": delete_schedule,
+                    "deleteScheduleBatch": delete_schedule_batch
+                }
+            )
+            raise_for_status_improved(response)
 
 
 class WorkflowsSyncModule(GenericSyncModule):


### PR DESCRIPTION
### Content
- Calls to delete-workflow-schedules new BC endpoint.
- Typo fix in import
- Remove `/check` from urls  in `check_credentials` (src/altscore/borrower_central/model/integrations/sri.py) requested by Cristian.