### PR TITLE
(ENG-67) Upload package attachments with classic method or signed url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = "Python SDK for AltScore"
 
 setup(
     name="altscore",
-    version="0.1.188",
+    version="0.1.189",
     description="Python SDK for AltScore. It provides a simple interface to the AltScore API.",
     package_dir={"": "src"},
     packages=find_packages(where="src"),

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = "Python SDK for AltScore"
 
 setup(
     name="altscore",
-    version="0.1.187",
+    version="0.1.188",
     description="Python SDK for AltScore. It provides a simple interface to the AltScore API.",
     package_dir={"": "src"},
     packages=find_packages(where="src"),

--- a/src/altscore/borrower_central/model/store_packages.py
+++ b/src/altscore/borrower_central/model/store_packages.py
@@ -98,6 +98,7 @@ class PackageSync(GenericSyncResource):
                 f"/v1/stores/packages/commands/attachments/generate-upload-signed-url",
                 json=GenerateAttachmentUploadSignedURL(file_name=file_name).dict(),
                 headers=headers,
+                timeout=900
             )
             raise_for_status_improved(response)
             signed_url = UploadSignedURLAPIDTO.parse_obj(response.json())
@@ -111,7 +112,8 @@ class PackageSync(GenericSyncResource):
                     headers={
                         "Content-Type": signed_url.content_type
                     },
-                    content=content
+                    content=content,
+                    timeout=900
                 )
 
                 raise_for_status_improved(response)
@@ -124,6 +126,7 @@ class PackageSync(GenericSyncResource):
                     package_id=self.data.id, attachment_file_name=signed_url.file_name, metadata=metadata, label=label
                 ).dict(),
                 headers=headers,
+                timeout=900
             )
             raise_for_status_improved(response)
 
@@ -162,7 +165,8 @@ class PackageAsync(GenericAsyncResource):
             response = await client.post(
                 f"/v1/stores/packages/commands/attachments/generate-upload-signed-url",
                 json=GenerateAttachmentUploadSignedURL(file_name=file_name).dict(),
-                headers=headers
+                headers=headers,
+                timeout=900
             )
             raise_for_status_improved(response)
 
@@ -177,7 +181,8 @@ class PackageAsync(GenericAsyncResource):
                 headers={
                     "Content-Type": signed_url.content_type
                 },
-                content=content
+                content=content,
+                timeout=900
             )
 
             raise_for_status_improved(response)
@@ -189,7 +194,8 @@ class PackageAsync(GenericAsyncResource):
                 json=CommitAttachmentSignedURUpload(
                     package_id=self.data.id, attachment_file_name=signed_url.file_name, metadata=metadata, label=label
                 ).dict(),
-                headers=headers
+                headers=headers,
+                timeout=900
             )
             raise_for_status_improved(response)
 

--- a/src/altscore/borrower_central/model/store_packages.py
+++ b/src/altscore/borrower_central/model/store_packages.py
@@ -132,7 +132,8 @@ class PackageSync(GenericSyncResource):
 
         file_size = os.path.getsize(file_path)
 
-        if file_size < max_cloud_run_allowed_size:
+        if False:
+            # if file_size < max_cloud_run_allowed_size:
             self.upload_attachment(
                 file_path=file_path,
                 label=label,

--- a/src/altscore/borrower_central/model/store_packages.py
+++ b/src/altscore/borrower_central/model/store_packages.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional, List, Dict, Any
 import httpx
 from altscore.altdata.model.data_request import RequestResult
@@ -6,6 +7,7 @@ from altscore.borrower_central.model.generics import GenericSyncResource, Generi
 from pydantic import BaseModel, Field
 import datetime as dt
 from dateutil.parser import parse as parse_date
+from altscore.common.http_errors import raise_for_status_improved, retry_on_401, retry_on_401_async
 
 
 class PackageAPIDTO(BaseModel):
@@ -46,16 +48,167 @@ class CreatePackageDTO(BaseModel):
         allow_population_by_alias = True
 
 
+class GenerateAttachmentUploadSignedURL(BaseModel):
+    file_name: str = Field(alias="fileName")
+
+    class Config:
+        populate_by_name = True
+        allow_population_by_field_name = True
+        allow_population_by_alias = True
+
+
+class CommitAttachmentSignedURUpload(BaseModel):
+    package_id: str = Field(alias="packageId")
+    attachment_file_name: str = Field(alias="attachmentFileName")
+    metadata: Optional[dict] = Field(alias="metadata", default=None)
+    label: Optional[str] = Field(alias="label", default=None)
+
+
+    class Config:
+        populate_by_name = True
+        allow_population_by_field_name = True
+        allow_population_by_alias = True
+
+
+class UploadSignedURLAPIDTO(BaseModel):
+    signed_url: str = Field(alias="signedUrl")
+    file_name: str = Field(alias="fileName")
+    content_type: str = Field(alias="contentType")
+    attachment_id: str = Field(alias="attachmentId")
+
+    class Config:
+        populate_by_name = True
+        allow_population_by_field_name = True
+        allow_population_by_alias = True
+
+
 class PackageSync(GenericSyncResource):
 
     def __init__(self, base_url, header_builder, renew_token, data: Dict):
         super().__init__(base_url, "/stores/packages", header_builder, renew_token, PackageAPIDTO.parse_obj(data))
 
 
+    @retry_on_401
+    def upload_attachment_with_signed_url(self, file_path: str,  label: str = None, metadata: Dict = None):
+        file_name = file_path.split("/")[-1]
+
+        with httpx.Client(base_url=self.base_url) as client:
+            headers = self._header_builder()
+            response = client.post(
+                f"/v1/stores/packages/commands/attachments/generate-upload-signed-url",
+                json=GenerateAttachmentUploadSignedURL(file_name=file_name).dict(),
+                headers=headers,
+            )
+            raise_for_status_improved(response)
+            signed_url = UploadSignedURLAPIDTO.parse_obj(response.json())
+
+        with open(file_path, "rb") as f:
+            content = f.read()
+
+            with httpx.Client() as client:
+                response = client.put(
+                    url=signed_url.signed_url,
+                    headers={
+                        "Content-Type": signed_url.content_type
+                    },
+                    content=content
+                )
+
+                raise_for_status_improved(response)
+
+        with httpx.Client(base_url=self.base_url) as client:
+            headers = self._header_builder()
+            response = client.post(
+                f"/v1/stores/packages/commands/attachments/commit-signed-url-upload",
+                json=CommitAttachmentSignedURUpload(
+                    package_id=self.data.id, attachment_file_name=signed_url.file_name, metadata=metadata, label=label
+                ).dict(),
+                headers=headers,
+            )
+            raise_for_status_improved(response)
+
+    def upload_package_attachment(self, file_path: str, label: str = None, metadata: Dict = None):
+        max_cloud_run_allowed_size = 32 * 1024 * 1024
+
+        file_size = os.path.getsize(file_path)
+
+        if file_size < max_cloud_run_allowed_size:
+            self.upload_attachment(
+                file_path=file_path,
+                label=label,
+                metadata=metadata
+            )
+        else:
+            self.upload_attachment_with_signed_url(
+                file_path = file_path,
+                label = label,
+                metadata = metadata
+            )
+
+
 class PackageAsync(GenericAsyncResource):
 
     def __init__(self, base_url, header_builder, renew_token, data: Dict):
         super().__init__(base_url, "/stores/packages", header_builder, renew_token, PackageAPIDTO.parse_obj(data))
+
+
+    @retry_on_401_async
+    async def upload_attachment_with_signed_url(self, file_path: str, label: str = None, metadata: Dict = None):
+        file_name = file_path.split("/")[-1]
+
+        async with httpx.AsyncClient(base_url=self.base_url) as client:
+            headers = self._header_builder()
+            response = await client.post(
+                f"/v1/stores/packages/commands/attachments/generate-upload-signed-url",
+                json=GenerateAttachmentUploadSignedURL(file_name=file_name).dict(),
+                headers=headers
+            )
+            raise_for_status_improved(response)
+
+            signed_url = UploadSignedURLAPIDTO.parse_obj(response.json())
+
+        with open(file_path, "rb") as f:
+            content = f.read()
+
+        with httpx.Client() as client:
+            response = client.put(
+                url=signed_url.signed_url,
+                headers={
+                    "Content-Type": signed_url.content_type
+                },
+                content=content
+            )
+
+            raise_for_status_improved(response)
+
+        async with httpx.AsyncClient(base_url=self.base_url) as client:
+            headers = self._header_builder()
+            response = await client.post(
+                f"/v1/stores/packages/commands/attachments/commit-signed-url-upload",
+                json=CommitAttachmentSignedURUpload(
+                    package_id=self.data.id, attachment_file_name=signed_url.file_name, metadata=metadata, label=label
+                ).dict(),
+                headers=headers
+            )
+            raise_for_status_improved(response)
+
+    async def upload_package_attachment(self, file_path: str, label: str = None, metadata: Dict = None):
+        max_cloud_run_allowed_size = 32 * 1024 * 1024
+
+        file_size = os.path.getsize(file_path)
+
+        if file_size < max_cloud_run_allowed_size:
+            await self.upload_attachment(
+                file_path=file_path,
+                label=label,
+                metadata=metadata
+            )
+        else:
+            await self.upload_attachment_with_signed_url(
+                file_path = file_path,
+                label = label,
+                metadata = metadata
+            )
 
 
 class PackagesSyncModule(GenericSyncModule):

--- a/src/altscore/borrower_central/model/store_packages.py
+++ b/src/altscore/borrower_central/model/store_packages.py
@@ -135,8 +135,7 @@ class PackageSync(GenericSyncResource):
 
         file_size = os.path.getsize(file_path)
 
-        if False:
-            # if file_size < max_cloud_run_allowed_size:
+        if file_size < max_cloud_run_allowed_size:
             self.upload_attachment(
                 file_path=file_path,
                 label=label,


### PR DESCRIPTION
### Content
- Implemented package attachment upload with signed url and created wrapper function that decides whether to upload the attachment using classic method (attachment data passing through the BC) or new method (signed url) according to the file size. If above 32MB (cloud run limit), it uses signed url.

### Note
- Depends on https://github.com/AltScore/borrower-central/pull/219