### PR TITLE
[FWD-248] allow skip verification to send SMS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = "Python SDK for AltScore"
 
 setup(
     name="altscore",
-    version="0.1.216",
+    version="0.1.217",
     description="Python SDK for AltScore. It provides a simple interface to the AltScore API.",
     package_dir={"": "src"},
     packages=find_packages(where="src"),

--- a/src/altscore/borrower_central/model/borrower.py
+++ b/src/altscore/borrower_central/model/borrower.py
@@ -1332,14 +1332,15 @@ class BorrowerAsync(BorrowerBase):
         return mapped_dict
 
     @retry_on_401_async
-    async def send_sms(self, message: str, point_of_contact_id: Optional[str] = None):
+    async def send_sms(self, message: str, point_of_contact_id: Optional[str] = None, skip_verification_check: Optional[bool] = False):
         async with httpx.AsyncClient(base_url=self.base_url) as client:
             response = await client.post(
                 f"{self.base_url}/v1/borrowers/{self.data.id}/communications/sms",
                 headers=self._header_builder(),
                 json={
                     "message": message,
-                    "pointOfContactId": point_of_contact_id
+                    "pointOfContactId": point_of_contact_id,
+                    "skipVerificationCheck": skip_verification_check
                 }
             )
             raise_for_status_improved(response)
@@ -1898,14 +1899,15 @@ class BorrowerSync(BorrowerBase):
         return mapped_dict
 
     @retry_on_401
-    def send_sms(self, message: str, point_of_contact_id: Optional[str] = None):
+    def send_sms(self, message: str, point_of_contact_id: Optional[str] = None, skip_verification_check: Optional[bool] = False ):
         with httpx.Client(base_url=self.base_url) as client:
             response = client.post(
                 f"{self.base_url}/v1/borrowers/{self.data.id}/communications/sms",
                 headers=self._header_builder(),
                 json={
                     "message": message,
-                    "pointOfContactId": point_of_contact_id
+                    "pointOfContactId": point_of_contact_id,
+                    "skipVerificationCheck": skip_verification_check
                 }
             )
             raise_for_status_improved(response)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to skip verification checks when sending SMS messages to borrowers.

* **Chores**
  * Updated the package version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->