### PR TITLE
Fix: error on Json decoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = "Python SDK for AltScore"
 
 setup(
     name="altscore",
-    version="0.1.219",
+    version="0.1.220",
     description="Python SDK for AltScore. It provides a simple interface to the AltScore API.",
     package_dir={"": "src"},
     packages=find_packages(where="src"),

--- a/src/altscore/borrower_central/model/conversational_templates.py
+++ b/src/altscore/borrower_central/model/conversational_templates.py
@@ -161,7 +161,6 @@ class WhatsAppTemplateSyncModule(GenericSyncModule):
                 timeout=120,
             )
             raise_for_status_improved(request)
-            return request.json()
 
 
 class WhatsAppTemplateAsyncModule(GenericAsyncModule):
@@ -201,5 +200,4 @@ class WhatsAppTemplateAsyncModule(GenericAsyncModule):
                 timeout=120,
             )
             raise_for_status_improved(response)
-            return response.json()
 


### PR DESCRIPTION
## Summary by Saúl:
When response was being parsed to JSON with `request.json()`, it was generating an error, it wasn't abled to be parsed to JSON.  The function raise_for_status_improved already raise an error if the response is not successful 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 0.1.220.

* **Refactor**
  * Adjusted internal handling of WhatsApp template sending methods; these methods no longer return a response to the caller. No changes to method signatures or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->