### PR TITLE
Deals on pkgs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = "Python SDK for AltScore"
 
 setup(
     name="altscore",
-    version="0.1.227",
+    version="0.1.228",
     description="Python SDK for AltScore. It provides a simple interface to the AltScore API.",
     package_dir={"": "src"},
     packages=find_packages(where="src"),

--- a/src/altscore/borrower_central/model/store_packages.py
+++ b/src/altscore/borrower_central/model/store_packages.py
@@ -13,6 +13,7 @@ from altscore.common.http_errors import raise_for_status_improved, retry_on_401,
 class PackageAPIDTO(BaseModel):
     id: str = Field(alias="id")
     borrower_id: Optional[str] = Field(alias="borrowerId")
+    deal_id: Optional[str] = Field(alias="dealId")
     source_id: Optional[str] = Field(alias="sourceId", default=None)
     alias: Optional[str] = Field(alias="alias", default=None)
     workflow_id: Optional[str] = Field(alias="workflowId", default=None)
@@ -33,6 +34,7 @@ class PackageAPIDTO(BaseModel):
 
 class CreatePackageDTO(BaseModel):
     borrower_id: Optional[str] = Field(alias="borrowerId", default=None)
+    deal_id: Optional[str] = Field(alias="dealId", default=None)
     source_id: Optional[str] = Field(alias="sourceId", default=None)
     workflow_id: Optional[str] = Field(alias="workflowId", default=None)
     alias: Optional[str] = Field(alias="alias", default=None)
@@ -279,13 +281,14 @@ class PackagesSyncModule(GenericSyncModule):
                     return package
         return None
 
-    def force_stale(self, package_id: Optional[str] = None, borrower_id: Optional[str] = None,
+    def force_stale(self, package_id: Optional[str] = None, borrower_id: Optional[str] = None, deal_id: Optional[str] = None,
                     workflow_id: Optional[str] = None, alias: Optional[str] = None):
-        if package_id is None and borrower_id is None and workflow_id is None and alias is None:
-            raise ValueError("At least one of package_id, borrower_id, workflow_id or alias must be provided")
+        if package_id is None and borrower_id is None and deal_id is None and workflow_id is None and alias is None:
+            raise ValueError("At least one of package_id, borrower_id, deal_id, workflow_id or alias must be provided")
         body = {
             "packageId": package_id,
             "borrowerId": borrower_id,
+            "dealId": deal_id,
             "workflowId": workflow_id,
             "alias": alias,
             "forcedStale": True

--- a/src/altscore/borrower_central/model/store_packages.py
+++ b/src/altscore/borrower_central/model/store_packages.py
@@ -13,7 +13,7 @@ from altscore.common.http_errors import raise_for_status_improved, retry_on_401,
 class PackageAPIDTO(BaseModel):
     id: str = Field(alias="id")
     borrower_id: Optional[str] = Field(alias="borrowerId")
-    deal_id: Optional[str] = Field(alias="dealId")
+    deal_id: Optional[str] = Field(alias="dealId", default = None)
     source_id: Optional[str] = Field(alias="sourceId", default=None)
     alias: Optional[str] = Field(alias="alias", default=None)
     workflow_id: Optional[str] = Field(alias="workflowId", default=None)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Packages can now be associated with a deal via an optional dealId.
  * dealId is accepted on create requests and returned in package responses.
  * You can trigger a package refresh using dealId in addition to other identifiers.
  * Validation now requires at least one identifier when forcing a refresh.

* **Chores**
  * Bumped package version to 0.1.228.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->