### PR TITLE
datamodel.datatype

### DIFF
--- a/src/altscore/borrower_central/model/data_models.py
+++ b/src/altscore/borrower_central/model/data_models.py
@@ -13,6 +13,7 @@ class DataModelAPIDTO(BaseModel):
     priority: Optional[int] = Field(alias="priority", default=None)
     order: Optional[int] = Field(alias="order", default=None)
     allowed_values: Optional[List[Any]] = Field(alias="allowedValues", default=None)
+    data_type: Optional[str] = Field(alias="dataType", default=None)
     created_at: str = Field(alias="createdAt")
     updated_at: Optional[str] = Field(alias="updatedAt")
     metadata: Optional[Dict[str, Any]] = Field(alias="metadata")
@@ -32,6 +33,7 @@ class DataModelCreate(BaseModel):
     priority: Optional[int] = Field(alias="priority", default=None)
     allowed_values: Optional[List[Any]] = Field(alias="allowedValues", default=None)
     order: Optional[int] = Field(alias="order", default=None)
+    data_type: Optional[str] = Field(alias="dataType", default=None)
     metadata: Optional[dict] = Field(alias="metadata", default={})
     is_segmentation_field: Optional[bool] = Field(alias="isSegmentationField", default=False)
 
@@ -48,6 +50,7 @@ class DataModelUpdate(BaseModel):
     priority: Optional[int] = Field(alias="priority", default=None)
     order: Optional[int] = Field(alias="order", default=None)
     allowed_values: Optional[List[Any]] = Field(alias="allowedValues", default=None)
+    data_type: Optional[str] = Field(alias="dataType", default=None)
     metadata: Optional[dict] = Field(alias="metadata", default={})
     is_segmentation_field: Optional[bool] = Field(alias="isSegmentationField", default=None)
 

--- a/src/altscore/borrower_central/model/deal_fields.py
+++ b/src/altscore/borrower_central/model/deal_fields.py
@@ -44,7 +44,7 @@ class CreateDealFieldRequest(BaseModel):
     deal_id: str = Field(alias="dealId")
     key: str = Field(alias="key")
     value: Any = Field(alias="value")
-    data_type: Literal["string", "number", "date", "boolean", "money"] = Field(alias="dataType")
+    data_type: Optional[Literal["string", "number", "date", "boolean", "money"]] = Field(alias="dataType", default=None)
     reference_id: Optional[str] = Field(alias="referenceId", default=None)
     tags: List[str] = Field(alias="tags", default=[])
 
@@ -58,6 +58,7 @@ class UpdateDealFieldRequest(BaseModel):
     """Model for updating a deal field"""
     deal_id: str = Field(alias="dealId")
     value: Any = Field(alias="value")
+    data_type: Optional[Literal["string", "number", "date", "boolean", "money"]] = Field(alias="dataType", default=None)
     reference_id: str = Field(alias="referenceId")  # Source of the value for history tracking
     tags: Optional[List[str]] = Field(alias="tags", default=[])
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional dataType field support across Data Models (create, update, read) and Deal Fields (create, update).
  - API now accepts and returns dataType when provided; valid values: string, number, date, boolean, money.
  - Backward-compatible: dataType is optional and defaults to none if omitted.
  - Responses will include dataType when set, enabling clearer typing of custom fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->