### PR TITLE
feat: default include-tests=true for entity queries by parent ID

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = "Python SDK for AltScore"
 
 setup(
     name="altscore",
-    version="0.1.266",
+    version="0.1.267",
     description="Python SDK for AltScore. It provides a simple interface to the AltScore API.",
     package_dir={"": "src"},
     packages=find_packages(where="src"),

--- a/src/altscore/borrower_central/model/asset_fields.py
+++ b/src/altscore/borrower_central/model/asset_fields.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field, root_validator
 from typing import Optional, List, Dict, Any
 from altscore.borrower_central.model.generics import GenericSyncResource, GenericAsyncResource, \
     GenericSyncModule, GenericAsyncModule
+from altscore.borrower_central.utils import build_test_params
 
 
 class Money(BaseModel):
@@ -132,26 +133,30 @@ class AssetFieldsSyncModule(GenericSyncModule):
                          resource="asset-fields")
 
     @retry_on_401
-    def get_by_asset_id(self, asset_id: str, page: int = 1, per_page: int = 100):
+    def get_by_asset_id(self, asset_id: str, page: int = 1, per_page: int = 100,
+                        include_tests: bool = True, test_only: bool = False):
         """
         Get asset fields by asset ID
-        
+
         Args:
             asset_id: The ID of the asset
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             List[AssetFieldDTO]: List of asset fields
         """
         with httpx.Client(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "asset-id": asset_id,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 "/v1/asset-fields",
-                params={
-                    "asset-id": asset_id,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -159,26 +164,30 @@ class AssetFieldsSyncModule(GenericSyncModule):
             return [AssetFieldDTO.parse_obj(data) for data in response.json()]
 
     @retry_on_401
-    def get_by_key(self, asset_id: str, key: str):
+    def get_by_key(self, asset_id: str, key: str,
+                   include_tests: bool = True, test_only: bool = False):
         """
         Get an asset field by its key
 
         Args:
             asset_id: The ID of the asset
             key: The field key
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
 
         Returns:
             List[AssetFieldDTO]: List of asset fields matching the key
         """
         with httpx.Client(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "key": key,
+                "asset-id": asset_id,
+                "per-page": 100,
+                "page": 1
+            }, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 "/v1/asset-fields",
-                params={
-                    "key": key,
-                    "asset-id": asset_id,
-                    "per-page": 100,
-                    "page": 1
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -197,26 +206,30 @@ class AssetFieldsAsyncModule(GenericAsyncModule):
                          resource="asset-fields")
 
     @retry_on_401_async
-    async def get_by_asset_id(self, asset_id: str, page: int = 1, per_page: int = 100):
+    async def get_by_asset_id(self, asset_id: str, page: int = 1, per_page: int = 100,
+                              include_tests: bool = True, test_only: bool = False):
         """
         Get asset fields by asset ID
-        
+
         Args:
             asset_id: The ID of the asset
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             List[AssetFieldDTO]: List of asset fields
         """
         async with httpx.AsyncClient(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "asset-id": asset_id,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 "/v1/asset-fields",
-                params={
-                    "asset-id": asset_id,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -224,26 +237,30 @@ class AssetFieldsAsyncModule(GenericAsyncModule):
             return [AssetFieldDTO.parse_obj(data) for data in response.json()]
 
     @retry_on_401_async
-    async def get_by_key(self, asset_id: str, key: str):
+    async def get_by_key(self, asset_id: str, key: str,
+                         include_tests: bool = True, test_only: bool = False):
         """
         Get an asset field by its key
-        
+
         Args:
             asset_id: The ID of the asset
             key: The field key
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             List[AssetFieldDTO]: List of asset fields matching the key
         """
         async with httpx.AsyncClient(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "key": key,
+                "asset-id": asset_id,
+                "per-page": 100,
+                "page": 1
+            }, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 "/v1/asset-fields",
-                params={
-                    "key": key,
-                    "asset-id": asset_id,
-                    "per-page": 100,
-                    "page": 1
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )

--- a/src/altscore/borrower_central/model/asset_fields.py
+++ b/src/altscore/borrower_central/model/asset_fields.py
@@ -61,24 +61,21 @@ class AssetFieldDTO(BaseModel):
         """Parse history values based on the field's data_type"""
         data_type = values.get("data_type")
         history = values.get("history", [])
-        
-        if not history:
-            return values
-        
+
         # Parse current value based on data_type
         current_value = values.get("value")
         if data_type == "money" and isinstance(current_value, dict):
             values["value"] = Money.parse_obj(current_value)
         elif data_type == "money_array" and isinstance(current_value, list):
             values["value"] = [MoneyArrayItemDTO.parse_obj(item) for item in current_value]
-        
+
         # Parse history values based on data_type
         for hist_item in history:
             if data_type == "money" and isinstance(hist_item.value, dict):
                 hist_item.value = Money.parse_obj(hist_item.value)
             elif data_type == "money_array" and isinstance(hist_item.value, list):
                 hist_item.value = [MoneyArrayItemDTO.parse_obj(item) for item in hist_item.value]
-        
+
         return values
 
 

--- a/src/altscore/borrower_central/model/assets.py
+++ b/src/altscore/borrower_central/model/assets.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field
 from typing import Optional, List, Dict
 from altscore.borrower_central.model.generics import GenericSyncResource, GenericAsyncResource, \
     GenericSyncModule, GenericAsyncModule
+from altscore.borrower_central.utils import build_test_params
 
 
 # DTO for assets
@@ -136,26 +137,30 @@ class AssetsSyncModule(GenericSyncModule):
             return None
 
     @retry_on_401
-    def query_by_deal_id(self, deal_id: str, page: int = 1, per_page: int = 10):
+    def query_by_deal_id(self, deal_id: str, page: int = 1, per_page: int = 10,
+                         include_tests: bool = True, test_only: bool = False):
         """
         Find assets by deal ID
-        
+
         Args:
             deal_id: The ID of the deal to filter by
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             Dict with assets and pagination info
         """
         with httpx.Client(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "deal-id": deal_id,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 "/v1/assets",
-                params={
-                    "deal-id": deal_id,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -163,14 +168,18 @@ class AssetsSyncModule(GenericSyncModule):
             return response.json()
 
     @retry_on_401
-    def retrieve_by_external_id(self, external_id: str) -> Optional[AssetSync]:
+    def retrieve_by_external_id(self, external_id: str,
+                                include_tests: bool = True, test_only: bool = False) -> Optional[AssetSync]:
         """
         Retrieve an asset by its external ID
         """
         with httpx.Client(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "external-id": external_id
+            }, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 "/v1/assets",
-                params={"external-id": external_id},
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -186,7 +195,8 @@ class AssetsSyncModule(GenericSyncModule):
             return None
 
     @retry_on_401
-    def query_by_group(self, group: str, page: int = 1, per_page: int = 10):
+    def query_by_group(self, group: str, page: int = 1, per_page: int = 10,
+                       include_tests: bool = True, test_only: bool = False):
         """
         Find assets by group
 
@@ -194,18 +204,21 @@ class AssetsSyncModule(GenericSyncModule):
             group: The group key to filter by
             page: Page number for pagination
             per_page: Number of results per page
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
 
         Returns:
             Dict with assets and pagination info
         """
         with httpx.Client(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "group": group,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 "/v1/assets",
-                params={
-                    "group": group,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -248,26 +261,30 @@ class AssetsAsyncModule(GenericAsyncModule):
             return None
 
     @retry_on_401_async
-    async def query_by_deal_id(self, deal_id: str, page: int = 1, per_page: int = 10):
+    async def query_by_deal_id(self, deal_id: str, page: int = 1, per_page: int = 10,
+                               include_tests: bool = True, test_only: bool = False):
         """
         Find assets by deal ID
-        
+
         Args:
             deal_id: The ID of the deal to filter by
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             Dict with assets and pagination info
         """
         async with httpx.AsyncClient(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "deal-id": deal_id,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 "/v1/assets",
-                params={
-                    "deal-id": deal_id,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -275,14 +292,18 @@ class AssetsAsyncModule(GenericAsyncModule):
             return response.json()
 
     @retry_on_401_async
-    async def retrieve_by_external_id(self, external_id: str) -> Optional[AssetAsync]:
+    async def retrieve_by_external_id(self, external_id: str,
+                                      include_tests: bool = True, test_only: bool = False) -> Optional[AssetAsync]:
         """
         Retrieve an asset by its external ID
         """
         async with httpx.AsyncClient(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "external-id": external_id
+            }, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 "/v1/assets",
-                params={"external-id": external_id},
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -298,7 +319,8 @@ class AssetsAsyncModule(GenericAsyncModule):
             return None
 
     @retry_on_401_async
-    async def query_by_group(self, group: str, page: int = 1, per_page: int = 10):
+    async def query_by_group(self, group: str, page: int = 1, per_page: int = 10,
+                             include_tests: bool = True, test_only: bool = False):
         """
         Find assets by group
 
@@ -306,18 +328,21 @@ class AssetsAsyncModule(GenericAsyncModule):
             group: The group key to filter by
             page: Page number for pagination
             per_page: Number of results per page
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
 
         Returns:
             Dict with assets and pagination info
         """
         async with httpx.AsyncClient(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "group": group,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 "/v1/assets",
-                params={
-                    "group": group,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )

--- a/src/altscore/borrower_central/model/borrower_fields.py
+++ b/src/altscore/borrower_central/model/borrower_fields.py
@@ -219,8 +219,16 @@ class BorrowerFieldsSyncModule(GenericSyncModule):
         Returns:
             List[BorrowerFieldSync]: List of borrower fields for the borrower
         """
-        return self.query(borrower_id=borrower_id, page=page, per_page=per_page,
-                          include_tests=include_tests, test_only=test_only)
+        query_kwargs = {
+            "borrower_id": borrower_id,
+            "page": page,
+            "per_page": per_page,
+        }
+        if test_only:
+            query_kwargs["test_only"] = True
+        elif include_tests:
+            query_kwargs["include_tests"] = True
+        return self.query(**query_kwargs)
 
 class BorrowerFieldsAsyncModule(GenericAsyncModule):
 
@@ -319,5 +327,13 @@ class BorrowerFieldsAsyncModule(GenericAsyncModule):
         Returns:
             List[BorrowerFieldAsync]: List of borrower fields for the borrower
         """
-        return await self.query(borrower_id=borrower_id, page=page, per_page=per_page,
-                                include_tests=include_tests, test_only=test_only)
+        query_kwargs = {
+            "borrower_id": borrower_id,
+            "page": page,
+            "per_page": per_page,
+        }
+        if test_only:
+            query_kwargs["test_only"] = True
+        elif include_tests:
+            query_kwargs["include_tests"] = True
+        return await self.query(**query_kwargs)

--- a/src/altscore/borrower_central/model/borrower_fields.py
+++ b/src/altscore/borrower_central/model/borrower_fields.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field, root_validator
 from typing import Optional, List, Dict, Any
 from altscore.borrower_central.model.generics import GenericSyncResource, GenericAsyncResource, \
     GenericSyncModule, GenericAsyncModule
+from altscore.borrower_central.utils import build_test_params
 import datetime as dt
 
 
@@ -132,16 +133,18 @@ class BorrowerFieldsSyncModule(GenericSyncModule):
                          resource="borrower-fields")
 
     @retry_on_401
-    def find_by_key(self, key: str, borrower_id: str):
+    def find_by_key(self, key: str, borrower_id: str,
+                    include_tests: bool = True, test_only: bool = False):
         with httpx.Client(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "key": key,
+                "borrower-id": borrower_id,
+                "per-page": 1,
+                "page": 1
+            }, include_tests=include_tests, test_only=test_only)
             fields_found_req = client.get(
                 f"/v1/borrower-fields",
-                params={
-                    "key": key,
-                    "borrower-id": borrower_id,
-                    "per-page": 1,
-                    "page": 1
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -201,19 +204,23 @@ class BorrowerFieldsSyncModule(GenericSyncModule):
             return
 
     @retry_on_401
-    def get_by_borrower_id(self, borrower_id: str, page: int = 1, per_page: int = 100):
+    def get_by_borrower_id(self, borrower_id: str, page: int = 1, per_page: int = 100,
+                           include_tests: bool = True, test_only: bool = False):
         """
         Get all borrower fields for a specific borrower
-        
+
         Args:
             borrower_id: The ID of the borrower
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             List[BorrowerFieldSync]: List of borrower fields for the borrower
         """
-        return self.query(borrower_id=borrower_id, page=page, per_page=per_page)
+        return self.query(borrower_id=borrower_id, page=page, per_page=per_page,
+                          include_tests=include_tests, test_only=test_only)
 
 class BorrowerFieldsAsyncModule(GenericAsyncModule):
 
@@ -226,16 +233,18 @@ class BorrowerFieldsAsyncModule(GenericAsyncModule):
                          resource="borrower-fields")
 
     @retry_on_401_async
-    async def find_by_key(self, key: str, borrower_id: str):
+    async def find_by_key(self, key: str, borrower_id: str,
+                          include_tests: bool = True, test_only: bool = False):
         async with httpx.AsyncClient(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "key": key,
+                "borrower-id": borrower_id,
+                "per-page": 1,
+                "page": 1
+            }, include_tests=include_tests, test_only=test_only)
             fields_found_req = await client.get(
                 f"/v1/borrower-fields",
-                params={
-                    "key": key,
-                    "borrower-id": borrower_id,
-                    "per-page": 1,
-                    "page": 1
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -295,16 +304,20 @@ class BorrowerFieldsAsyncModule(GenericAsyncModule):
             raise_for_status_improved(response)
 
     @retry_on_401_async
-    async def get_by_borrower_id(self, borrower_id: str, page: int = 1, per_page: int = 100):
+    async def get_by_borrower_id(self, borrower_id: str, page: int = 1, per_page: int = 100,
+                                 include_tests: bool = True, test_only: bool = False):
         """
         Get all borrower fields for a specific borrower
-        
+
         Args:
             borrower_id: The ID of the borrower
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             List[BorrowerFieldAsync]: List of borrower fields for the borrower
         """
-        return await self.query(borrower_id=borrower_id, page=page, per_page=per_page)
+        return await self.query(borrower_id=borrower_id, page=page, per_page=per_page,
+                                include_tests=include_tests, test_only=test_only)

--- a/src/altscore/borrower_central/model/deal_contacts.py
+++ b/src/altscore/borrower_central/model/deal_contacts.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field
 from typing import Optional, Dict
 from altscore.borrower_central.model.generics import GenericSyncResource, GenericAsyncResource, \
     GenericSyncModule, GenericAsyncModule
+from altscore.borrower_central.utils import build_test_params
 
 
 # DTO for deal contacts
@@ -70,26 +71,30 @@ class DealContactsSyncModule(GenericSyncModule):
                          resource="deal-contacts")
 
     @retry_on_401
-    def get_by_deal_id(self, deal_id: str, page: int = 1, per_page: int = 100):
+    def get_by_deal_id(self, deal_id: str, page: int = 1, per_page: int = 100,
+                       include_tests: bool = True, test_only: bool = False):
         """
         Get all contacts for a specific deal
-        
+
         Args:
             deal_id: The ID of the deal
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             List[DealContactDTO]: List of contacts for the deal
         """
         with httpx.Client(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "deal-id": deal_id,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 "/v1/deal-contacts",
-                params={
-                    "deal-id": deal_id,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -97,26 +102,30 @@ class DealContactsSyncModule(GenericSyncModule):
             return [DealContactDTO.parse_obj(data) for data in response.json()]
 
     @retry_on_401
-    def get_by_borrower_id(self, borrower_id: str, page: int = 1, per_page: int = 100):
+    def get_by_borrower_id(self, borrower_id: str, page: int = 1, per_page: int = 100,
+                           include_tests: bool = True, test_only: bool = False):
         """
         Get all deal contacts for a specific borrower
-        
+
         Args:
             borrower_id: The ID of the borrower
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             List[DealContactDTO]: List of deal contacts for the borrower
         """
         with httpx.Client(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "borrower-id": borrower_id,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 "/v1/deal-contacts",
-                params={
-                    "borrower-id": borrower_id,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -124,55 +133,63 @@ class DealContactsSyncModule(GenericSyncModule):
             return [DealContactDTO.parse_obj(data) for data in response.json()]
 
     @retry_on_401
-    def get_by_deal_and_borrower(self, deal_id: str, borrower_id: str, page: int = 1, per_page: int = 100):
+    def get_by_deal_and_borrower(self, deal_id: str, borrower_id: str, page: int = 1, per_page: int = 100,
+                                 include_tests: bool = True, test_only: bool = False):
         """
         Get all contacts for a specific deal and borrower
-        
+
         Args:
             deal_id: The ID of the deal
             borrower_id: The ID of the borrower
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             List[DealContactDTO]: List of contacts for the deal and borrower
         """
         with httpx.Client(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "deal-id": deal_id,
+                "borrower-id": borrower_id,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 "/v1/deal-contacts",
-                params={
-                    "deal-id": deal_id,
-                    "borrower-id": borrower_id,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
             raise_for_status_improved(response)
             return [DealContactDTO.parse_obj(data) for data in response.json()]
-    
+
     @retry_on_401
-    def get_by_role_key(self, role_key: str, page: int = 1, per_page: int = 100):
+    def get_by_role_key(self, role_key: str, page: int = 1, per_page: int = 100,
+                        include_tests: bool = True, test_only: bool = False):
         """
         Get all contacts with a specific role
-        
+
         Args:
             role_key: The role key to filter by
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             List[DealContactDTO]: List of contacts with the specified role
         """
         with httpx.Client(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "role-key": role_key,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 "/v1/deal-contacts",
-                params={
-                    "role-key": role_key,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -191,26 +208,30 @@ class DealContactsAsyncModule(GenericAsyncModule):
                          resource="deal-contacts")
 
     @retry_on_401_async
-    async def get_by_deal_id(self, deal_id: str, page: int = 1, per_page: int = 100):
+    async def get_by_deal_id(self, deal_id: str, page: int = 1, per_page: int = 100,
+                             include_tests: bool = True, test_only: bool = False):
         """
         Get all contacts for a specific deal
-        
+
         Args:
             deal_id: The ID of the deal
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             List[DealContactDTO]: List of contacts for the deal
         """
         async with httpx.AsyncClient(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "deal-id": deal_id,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 "/v1/deal-contacts",
-                params={
-                    "deal-id": deal_id,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -218,26 +239,30 @@ class DealContactsAsyncModule(GenericAsyncModule):
             return [DealContactDTO.parse_obj(data) for data in response.json()]
 
     @retry_on_401_async
-    async def get_by_borrower_id(self, borrower_id: str, page: int = 1, per_page: int = 100):
+    async def get_by_borrower_id(self, borrower_id: str, page: int = 1, per_page: int = 100,
+                                 include_tests: bool = True, test_only: bool = False):
         """
         Get all deal contacts for a specific borrower
-        
+
         Args:
             borrower_id: The ID of the borrower
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             List[DealContactDTO]: List of deal contacts for the borrower
         """
         async with httpx.AsyncClient(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "borrower-id": borrower_id,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 "/v1/deal-contacts",
-                params={
-                    "borrower-id": borrower_id,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -245,55 +270,63 @@ class DealContactsAsyncModule(GenericAsyncModule):
             return [DealContactDTO.parse_obj(data) for data in response.json()]
 
     @retry_on_401_async
-    async def get_by_deal_and_borrower(self, deal_id: str, borrower_id: str, page: int = 1, per_page: int = 100):
+    async def get_by_deal_and_borrower(self, deal_id: str, borrower_id: str, page: int = 1, per_page: int = 100,
+                                       include_tests: bool = True, test_only: bool = False):
         """
         Get all contacts for a specific deal and borrower
-        
+
         Args:
             deal_id: The ID of the deal
             borrower_id: The ID of the borrower
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             List[DealContactDTO]: List of contacts for the deal and borrower
         """
         async with httpx.AsyncClient(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "deal-id": deal_id,
+                "borrower-id": borrower_id,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 "/v1/deal-contacts",
-                params={
-                    "deal-id": deal_id,
-                    "borrower-id": borrower_id,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
             raise_for_status_improved(response)
             return [DealContactDTO.parse_obj(data) for data in response.json()]
-    
+
     @retry_on_401_async
-    async def get_by_role_key(self, role_key: str, page: int = 1, per_page: int = 100):
+    async def get_by_role_key(self, role_key: str, page: int = 1, per_page: int = 100,
+                              include_tests: bool = True, test_only: bool = False):
         """
         Get all contacts with a specific role
-        
+
         Args:
             role_key: The role key to filter by
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             List[DealContactDTO]: List of contacts with the specified role
         """
         async with httpx.AsyncClient(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "role-key": role_key,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 "/v1/deal-contacts",
-                params={
-                    "role-key": role_key,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )

--- a/src/altscore/borrower_central/model/deal_fields.py
+++ b/src/altscore/borrower_central/model/deal_fields.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field, root_validator
 from typing import Optional, List, Dict, Any
 from altscore.borrower_central.model.generics import GenericSyncResource, GenericAsyncResource, \
     GenericSyncModule, GenericAsyncModule
+from altscore.borrower_central.utils import build_test_params
 
 
 class Money(BaseModel):
@@ -142,26 +143,30 @@ class DealFieldsSyncModule(GenericSyncModule):
                          resource="deal-fields")
 
     @retry_on_401
-    def get_by_deal_id(self, deal_id: str, page: int = 1, per_page: int = 100):
+    def get_by_deal_id(self, deal_id: str, page: int = 1, per_page: int = 100,
+                       include_tests: bool = True, test_only: bool = False):
         """
         Get deal fields by deal ID
-        
+
         Args:
             deal_id: The ID of the deal
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             List[DealFieldDTO]: List of deal fields
         """
         with httpx.Client(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "deal-id": deal_id,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 "/v1/deal-fields",
-                params={
-                    "deal-id": deal_id,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -169,26 +174,30 @@ class DealFieldsSyncModule(GenericSyncModule):
             return [DealFieldDTO.parse_obj(data) for data in response.json()]
 
     @retry_on_401
-    def get_by_key(self, deal_id: str, key: str):
+    def get_by_key(self, deal_id: str, key: str,
+                   include_tests: bool = True, test_only: bool = False):
         """
         Get a deal field by its key
 
         Args:
             deal_id: The ID of the deal
             key: The field key
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
 
         Returns:
             List[DealFieldDTO]: List of deal fields matching the key
         """
         with httpx.Client(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "key": key,
+                "deal-id": deal_id,
+                "per-page": 100,
+                "page": 1
+            }, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 "/v1/deal-fields",
-                params={
-                    "key": key,
-                    "deal-id": deal_id,
-                    "per-page": 100,
-                    "page": 1
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -253,26 +262,30 @@ class DealFieldsAsyncModule(GenericAsyncModule):
                          resource="deal-fields")
 
     @retry_on_401_async
-    async def get_by_deal_id(self, deal_id: str, page: int = 1, per_page: int = 100):
+    async def get_by_deal_id(self, deal_id: str, page: int = 1, per_page: int = 100,
+                             include_tests: bool = True, test_only: bool = False):
         """
         Get deal fields by deal ID
-        
+
         Args:
             deal_id: The ID of the deal
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             List[DealFieldDTO]: List of deal fields
         """
         async with httpx.AsyncClient(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "deal-id": deal_id,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 "/v1/deal-fields",
-                params={
-                    "deal-id": deal_id,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -280,26 +293,30 @@ class DealFieldsAsyncModule(GenericAsyncModule):
             return [DealFieldDTO.parse_obj(data) for data in response.json()]
 
     @retry_on_401_async
-    async def get_by_key(self, deal_id: str, key: str):
+    async def get_by_key(self, deal_id: str, key: str,
+                         include_tests: bool = True, test_only: bool = False):
         """
         Get a deal field by its key
-        
+
         Args:
             deal_id: The ID of the deal
             key: The field key
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             List[DealFieldDTO]: List of deal fields matching the key
         """
         async with httpx.AsyncClient(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "key": key,
+                "deal-id": deal_id,
+                "per-page": 100,
+                "page": 1
+            }, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 "/v1/deal-fields",
-                params={
-                    "key": key,
-                    "deal-id": deal_id,
-                    "per-page": 100,
-                    "page": 1
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )

--- a/src/altscore/borrower_central/model/deal_steps.py
+++ b/src/altscore/borrower_central/model/deal_steps.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field
 from typing import Optional, List, Dict, Any, Union
 from altscore.borrower_central.model.generics import GenericSyncResource, GenericAsyncResource, \
     GenericSyncModule, GenericAsyncModule
+from altscore.borrower_central.utils import build_test_params
 
 
 # DTO for deal steps
@@ -71,26 +72,30 @@ class DealStepsSyncModule(GenericSyncModule):
                          resource="deal-steps")
 
     @retry_on_401
-    def get_by_deal_id(self, deal_id: str, page: int = 1, per_page: int = 100):
+    def get_by_deal_id(self, deal_id: str, page: int = 1, per_page: int = 100,
+                       include_tests: bool = True, test_only: bool = False):
         """
         Get all steps for a specific deal
-        
+
         Args:
             deal_id: The ID of the deal
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             List[DealStepDTO]: List of steps for the deal
         """
         with httpx.Client(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "deal-id": deal_id,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 "/v1/deal-steps",
-                params={
-                    "deal-id": deal_id,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -125,26 +130,30 @@ class DealStepsSyncModule(GenericSyncModule):
             )
 
     @retry_on_401
-    def get_by_key(self, deal_id: str, key: str, page: int = 1, per_page: int = 100):
+    def get_by_key(self, deal_id: str, key: str, page: int = 1, per_page: int = 100,
+                   include_tests: bool = True, test_only: bool = False):
         """
         Get all steps with a specific key for a deal
-        
+
         Args:
             deal_id: The ID of the deal
             key: The step key
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             List[DealStepDTO]: List of steps matching the key
         """
         with httpx.Client(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 f"/v1/deal-steps/by-key/{deal_id}/{key}",
-                params={
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -163,26 +172,30 @@ class DealStepsAsyncModule(GenericAsyncModule):
                          resource="deal-steps")
 
     @retry_on_401_async
-    async def get_by_deal_id(self, deal_id: str, page: int = 1, per_page: int = 100):
+    async def get_by_deal_id(self, deal_id: str, page: int = 1, per_page: int = 100,
+                             include_tests: bool = True, test_only: bool = False):
         """
         Get all steps for a specific deal
-        
+
         Args:
             deal_id: The ID of the deal
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             List[DealStepDTO]: List of steps for the deal
         """
         async with httpx.AsyncClient(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "deal-id": deal_id,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 "/v1/deal-steps",
-                params={
-                    "deal-id": deal_id,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -217,26 +230,30 @@ class DealStepsAsyncModule(GenericAsyncModule):
             )
 
     @retry_on_401_async
-    async def get_by_key(self, deal_id: str, key: str, page: int = 1, per_page: int = 100):
+    async def get_by_key(self, deal_id: str, key: str, page: int = 1, per_page: int = 100,
+                         include_tests: bool = True, test_only: bool = False):
         """
         Get all steps with a specific key for a deal
-        
+
         Args:
             deal_id: The ID of the deal
             key: The step key
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             List[DealStepDTO]: List of steps matching the key
         """
         async with httpx.AsyncClient(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 f"/v1/deal-steps/by-key/{deal_id}/{key}",
-                params={
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )

--- a/src/altscore/borrower_central/model/deals.py
+++ b/src/altscore/borrower_central/model/deals.py
@@ -6,7 +6,7 @@ from typing import Optional, List, Dict
 from altscore.borrower_central.model.generics import GenericSyncResource, GenericAsyncResource, \
     GenericSyncModule, GenericAsyncModule
 from altscore.borrower_central.model.deal_fields import DealFieldSync, DealFieldAsync
-from altscore.borrower_central.utils import clean_dict
+from altscore.borrower_central.utils import clean_dict, build_test_params
 
 
 # DTO for current step in a deal
@@ -117,7 +117,8 @@ class DealSync(GenericSyncResource):
 
     def _deal_fields(
             self, deal_id: str, key: Optional[str] = None, sort_by: Optional[str] = None,
-            per_page: Optional[int] = None, page: Optional[int] = None, sort_direction: Optional[str] = None
+            per_page: Optional[int] = None, page: Optional[int] = None, sort_direction: Optional[str] = None,
+            include_tests: bool = True, test_only: bool = False
     ) -> (str, dict):
         query = {
             "deal-id": deal_id,
@@ -127,13 +128,15 @@ class DealSync(GenericSyncResource):
             "page": page,
             "sort-direction": sort_direction
         }
-        return f"{self.base_url}/v1/deal-fields", clean_dict(query)
+        return f"{self.base_url}/v1/deal-fields", build_test_params(
+            clean_dict(query), include_tests=include_tests, test_only=test_only
+        )
 
     @retry_on_401
     def get_current_step(self):
         """
         Get the current step for a deal
-        
+
         Returns:
             DealStepDTO: The current step
         """
@@ -156,11 +159,11 @@ class DealSync(GenericSyncResource):
     def set_current_step(self, key: str, comment: Optional[str] = None):
         """
         Set the current step for a deal
-        
+
         Args:
             key: The key of the step to set as current
             comment: Optional comment for the step change
-            
+
         Returns:
             None
         """
@@ -177,7 +180,7 @@ class DealSync(GenericSyncResource):
     def get_steps(self):
         """
         Get all steps for this deal
-        
+
         Returns:
             List[DealStepDTO]: List of all steps for this deal
         """
@@ -192,18 +195,22 @@ class DealSync(GenericSyncResource):
             return [DealStepDTO.parse_obj(data) for data in response.json()]
 
     @retry_on_401
-    def get_deal_field_by_key(self, key: str) -> Optional[DealFieldSync]:
+    def get_deal_field_by_key(self, key: str, include_tests: bool = True,
+                              test_only: bool = False) -> Optional[DealFieldSync]:
         """
         Get a deal field by its key
-        
+
         Args:
             key: The field key
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             Optional[DealFieldSync]: The deal field if found, None otherwise
         """
         with httpx.Client(base_url=self.base_url) as client:
-            url, query = self._deal_fields(self.data.id, key=key)
+            url, query = self._deal_fields(self.data.id, key=key,
+                                           include_tests=include_tests, test_only=test_only)
             response = client.get(
                 url,
                 headers=self._header_builder(),
@@ -224,10 +231,11 @@ class DealSync(GenericSyncResource):
     def get_deal_fields(self, **kwargs) -> List[DealFieldSync]:
         """
         Get all deal fields for this deal
-        
+
         Args:
-            **kwargs: Optional query parameters (sort_by, per_page, page, sort_direction)
-            
+            **kwargs: Optional query parameters (sort_by, per_page, page, sort_direction,
+                      include_tests, test_only)
+
         Returns:
             List[DealFieldSync]: List of deal fields
         """
@@ -303,7 +311,8 @@ class DealAsync(GenericAsyncResource):
 
     def _deal_fields(
             self, deal_id: str, key: Optional[str] = None, sort_by: Optional[str] = None,
-            per_page: Optional[int] = None, page: Optional[int] = None, sort_direction: Optional[str] = None
+            per_page: Optional[int] = None, page: Optional[int] = None, sort_direction: Optional[str] = None,
+            include_tests: bool = True, test_only: bool = False
     ) -> (str, dict):
         query = {
             "deal-id": deal_id,
@@ -313,13 +322,15 @@ class DealAsync(GenericAsyncResource):
             "page": page,
             "sort-direction": sort_direction
         }
-        return f"{self.base_url}/v1/deal-fields", clean_dict(query)
+        return f"{self.base_url}/v1/deal-fields", build_test_params(
+            clean_dict(query), include_tests=include_tests, test_only=test_only
+        )
 
     @retry_on_401_async
     async def get_current_step(self):
         """
         Get the current step for a deal
-        
+
         Returns:
             DealStepDTO: The current step
         """
@@ -342,11 +353,11 @@ class DealAsync(GenericAsyncResource):
     async def set_current_step(self, key: str, comment: Optional[str] = None):
         """
         Set the current step for a deal
-        
+
         Args:
             key: The key of the step to set as current
             comment: Optional comment for the step change
-            
+
         Returns:
             None
         """
@@ -363,7 +374,7 @@ class DealAsync(GenericAsyncResource):
     async def get_steps(self):
         """
         Get all steps for this deal
-        
+
         Returns:
             List[DealStepDTO]: List of all steps for this deal
         """
@@ -378,18 +389,22 @@ class DealAsync(GenericAsyncResource):
             return [DealStepDTO.parse_obj(data) for data in response.json()]
 
     @retry_on_401_async
-    async def get_deal_field_by_key(self, key: str) -> Optional[DealFieldAsync]:
+    async def get_deal_field_by_key(self, key: str, include_tests: bool = True,
+                                    test_only: bool = False) -> Optional[DealFieldAsync]:
         """
         Get a deal field by its key
-        
+
         Args:
             key: The field key
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             Optional[DealFieldAsync]: The deal field if found, None otherwise
         """
         async with httpx.AsyncClient(base_url=self.base_url) as client:
-            url, query = self._deal_fields(self.data.id, key=key)
+            url, query = self._deal_fields(self.data.id, key=key,
+                                           include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 url,
                 headers=self._header_builder(),
@@ -410,10 +425,11 @@ class DealAsync(GenericAsyncResource):
     async def get_deal_fields(self, **kwargs) -> List[DealFieldAsync]:
         """
         Get all deal fields for this deal
-        
+
         Args:
-            **kwargs: Optional query parameters (sort_by, per_page, page, sort_direction)
-            
+            **kwargs: Optional query parameters (sort_by, per_page, page, sort_direction,
+                      include_tests, test_only)
+
         Returns:
             List[DealFieldAsync]: List of deal fields
         """
@@ -505,26 +521,30 @@ class DealsSyncModule(GenericSyncModule):
             return None
 
     @retry_on_401
-    def query_by_borrower_id(self, borrower_id: str, page: int = 1, per_page: int = 10):
+    def query_by_borrower_id(self, borrower_id: str, page: int = 1, per_page: int = 10,
+                             include_tests: bool = True, test_only: bool = False):
         """
         Find deals by borrower ID
-        
+
         Args:
             borrower_id: The ID of the borrower to filter by
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             Dict with deals and pagination info
         """
         with httpx.Client(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "borrower-id": borrower_id,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 "/v1/deals",
-                params={
-                    "borrower-id": borrower_id,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -532,26 +552,30 @@ class DealsSyncModule(GenericSyncModule):
             return response.json()
 
     @retry_on_401
-    def query_by_status(self, status: str, page: int = 1, per_page: int = 10):
+    def query_by_status(self, status: str, page: int = 1, per_page: int = 10,
+                        include_tests: bool = True, test_only: bool = False):
         """
         Find deals by status
-        
+
         Args:
             status: The status to filter by
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             Dict with deals and pagination info
         """
         with httpx.Client(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "status": status,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 "/v1/deals",
-                params={
-                    "status": status,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -559,14 +583,18 @@ class DealsSyncModule(GenericSyncModule):
             return response.json()
 
     @retry_on_401
-    def retrieve_by_external_id(self, external_id: str) -> Optional[DealSync]:
+    def retrieve_by_external_id(self, external_id: str,
+                                include_tests: bool = True, test_only: bool = False) -> Optional[DealSync]:
         """
         Retrieve a deal by its external ID
         """
         with httpx.Client(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "external-id": external_id
+            }, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 "/v1/deals",
-                params={"external-id": external_id},
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -617,26 +645,30 @@ class DealsAsyncModule(GenericAsyncModule):
             return None
 
     @retry_on_401_async
-    async def query_by_borrower_id(self, borrower_id: str, page: int = 1, per_page: int = 10):
+    async def query_by_borrower_id(self, borrower_id: str, page: int = 1, per_page: int = 10,
+                                   include_tests: bool = True, test_only: bool = False):
         """
         Find deals by borrower ID
-        
+
         Args:
             borrower_id: The ID of the borrower to filter by
             page: Page number for pagination
             per_page: Number of results per page
-            
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
+
         Returns:
             Dict with deals and pagination info
         """
         async with httpx.AsyncClient(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "borrower-id": borrower_id,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 "/v1/deals",
-                params={
-                    "borrower-id": borrower_id,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -644,7 +676,8 @@ class DealsAsyncModule(GenericAsyncModule):
             return response.json()
 
     @retry_on_401_async
-    async def query_by_status(self, status: str, page: int = 1, per_page: int = 10):
+    async def query_by_status(self, status: str, page: int = 1, per_page: int = 10,
+                              include_tests: bool = True, test_only: bool = False):
         """
         Find deals by status
 
@@ -652,18 +685,21 @@ class DealsAsyncModule(GenericAsyncModule):
             status: The status to filter by
             page: Page number for pagination
             per_page: Number of results per page
+            include_tests: Include test entities in results (default True)
+            test_only: Return only test entities (default False)
 
         Returns:
             Dict with deals and pagination info
         """
         async with httpx.AsyncClient(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "status": status,
+                "page": page,
+                "per-page": per_page
+            }, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 "/v1/deals",
-                params={
-                    "status": status,
-                    "page": page,
-                    "per-page": per_page
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -671,14 +707,18 @@ class DealsAsyncModule(GenericAsyncModule):
             return response.json()
 
     @retry_on_401_async
-    async def retrieve_by_external_id(self, external_id: str) -> Optional[DealAsync]:
+    async def retrieve_by_external_id(self, external_id: str,
+                                      include_tests: bool = True, test_only: bool = False) -> Optional[DealAsync]:
         """
         Retrieve a deal by its external ID
         """
         async with httpx.AsyncClient(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "external-id": external_id
+            }, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 "/v1/deals",
-                params={"external-id": external_id},
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )

--- a/src/altscore/borrower_central/model/identities.py
+++ b/src/altscore/borrower_central/model/identities.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field
 from typing import Optional, List, Dict
 from altscore.borrower_central.model.generics import GenericSyncResource, GenericAsyncResource, \
     GenericSyncModule, GenericAsyncModule
+from altscore.borrower_central.utils import build_test_params
 
 
 class IdentityAPIDTO(BaseModel):
@@ -102,16 +103,18 @@ class IdentitiesSyncModule(GenericSyncModule):
                          resource="identities")
 
     @retry_on_401
-    def find_by_key(self, key: str, borrower_id: str):
+    def find_by_key(self, key: str, borrower_id: str,
+                    include_tests: bool = True, test_only: bool = False):
         with httpx.Client(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "key": key,
+                "borrower-id": borrower_id,
+                "per-page": 1,
+                "page": 1
+            }, include_tests=include_tests, test_only=test_only)
             identities_found_req = client.get(
                 "/v1/identities",
-                params={
-                    "key": key,
-                    "borrower-id": borrower_id,
-                    "per-page": 1,
-                    "page": 1
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -150,16 +153,18 @@ class IdentitiesAsyncModule(GenericAsyncModule):
                          resource="identities")
 
     @retry_on_401_async
-    async def find_by_key(self, key: str, borrower_id: str):
+    async def find_by_key(self, key: str, borrower_id: str,
+                          include_tests: bool = True, test_only: bool = False):
         async with httpx.AsyncClient(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "key": key,
+                "borrower-id": borrower_id,
+                "per-page": 1,
+                "page": 1
+            }, include_tests=include_tests, test_only=test_only)
             identities_found_req = await client.get(
                 "/v1/identities",
-                params={
-                    "key": key,
-                    "borrower-id": borrower_id,
-                    "per-page": 1,
-                    "page": 1
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )

--- a/src/altscore/borrower_central/model/metrics.py
+++ b/src/altscore/borrower_central/model/metrics.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field
 from typing import Optional, List, Dict, Any
 from altscore.borrower_central.model.generics import GenericSyncResource, GenericAsyncResource, \
     GenericSyncModule, GenericAsyncModule
+from altscore.borrower_central.utils import build_test_params
 
 
 class HistoricValue(BaseModel):
@@ -111,16 +112,18 @@ class MetricsSyncModule(GenericSyncModule):
             return None
 
     @retry_on_401
-    def find_borrower_metric_by_key(self, borrower_id: str, key: str):
+    def find_borrower_metric_by_key(self, borrower_id: str, key: str,
+                                    include_tests: bool = True, test_only: bool = False):
         with httpx.Client(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "borrower-id": borrower_id,
+                "key": key,
+                "per-page": 1,
+                "page": 1
+            }, include_tests=include_tests, test_only=test_only)
             metrics_found_request = client.get(
                 f"/v1/metrics",
-                params={
-                    "borrower-id": borrower_id,
-                    "key": key,
-                    "per-page": 1,
-                    "page": 1
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -164,16 +167,18 @@ class MetricsAsyncModule(GenericAsyncModule):
                 return await self.retrieve(metrics_found_data[0]["id"])
 
     @retry_on_401_async
-    async def find_borrower_metric_by_key(self, borrower_id: str, key: str):
+    async def find_borrower_metric_by_key(self, borrower_id: str, key: str,
+                                          include_tests: bool = True, test_only: bool = False):
         async with httpx.AsyncClient(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "borrower-id": borrower_id,
+                "key": key,
+                "per-page": 1,
+                "page": 1
+            }, include_tests=include_tests, test_only=test_only)
             metrics_found_request = await client.get(
                 f"/v1/metrics",
-                params={
-                    "borrower-id": borrower_id,
-                    "key": key,
-                    "per-page": 1,
-                    "page": 1
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )

--- a/src/altscore/borrower_central/model/metrics.py
+++ b/src/altscore/borrower_central/model/metrics.py
@@ -103,13 +103,11 @@ class MetricsSyncModule(GenericSyncModule):
                 headers=self.build_headers(),
                 timeout=120,
             )
-            if metrics_found_request.status_code == 200:
-                metrics_found_data = metrics_found_request.json()
-                if len(metrics_found_data) == 0:
-                    return None
-                else:
-                    return self.retrieve(metrics_found_data[0]["id"])
-            return None
+            raise_for_status_improved(metrics_found_request)
+            metrics_found_data = metrics_found_request.json()
+            if len(metrics_found_data) == 0:
+                return None
+            return self.retrieve(metrics_found_data[0]["id"])
 
     @retry_on_401
     def find_borrower_metric_by_key(self, borrower_id: str, key: str,
@@ -127,13 +125,11 @@ class MetricsSyncModule(GenericSyncModule):
                 headers=self.build_headers(),
                 timeout=120,
             )
-            if metrics_found_request.status_code == 200:
-                metrics_found_data = metrics_found_request.json()
-                if len(metrics_found_data) == 0:
-                    return None
-                else:
-                    return self.retrieve(metrics_found_data[0]["id"])
-            return None
+            raise_for_status_improved(metrics_found_request)
+            metrics_found_data = metrics_found_request.json()
+            if len(metrics_found_data) == 0:
+                return None
+            return self.retrieve(metrics_found_data[0]["id"])
 
 
 class MetricsAsyncModule(GenericAsyncModule):

--- a/src/altscore/borrower_central/utils.py
+++ b/src/altscore/borrower_central/utils.py
@@ -8,3 +8,11 @@ def clean_dict(d: dict) -> dict:
 def convert_to_dash_case(s):
     snake_case = stringcase.snakecase(s)
     return stringcase.spinalcase(snake_case)
+
+
+def build_test_params(params: dict, include_tests: bool = True, test_only: bool = False) -> dict:
+    if test_only:
+        params["test-only"] = "true"
+    elif include_tests:
+        params["include-tests"] = "true"
+    return params


### PR DESCRIPTION
## Summary

- When querying child entities by parent ID (deal fields, deal contacts, deal steps, assets, asset fields, borrower fields, identities, metrics), the API defaults to excluding test entities (`is_test != true`). This caused empty results when working with UAT/test deals (HQ-733).
- Added `include_tests` (default `True`) and `test_only` (default `False`) params to all custom query methods across 9 entity modules, matching the frontend pattern of always passing `include-tests=true`.
- Added `build_test_params` helper in `utils.py` to centralize the query param logic.
- Bumped version to 0.1.267.

## Test plan

- [ ] Verify `deal.get_deal_fields()` returns fields for test deals without needing to pass any extra params
- [ ] Verify `deal_contacts.get_by_deal_id(deal_id)` returns contacts for test deals
- [ ] Verify passing `include_tests=False` excludes test entities
- [ ] Verify passing `test_only=True` returns only test entities
- [ ] Test with deal `485edbd9-0f29-4080-84f4-29f3ec933eb7` from HQ-733

Closes HQ-733

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional include_tests and test_only flags to query/retrieval methods across Assets, Borrower fields, Deals, Deal contacts, Deal fields/steps, Identities, and Metrics to control test-data filtering.
  * Added a utility to construct test-aware query parameters used by those methods.

* **Improvements**
  * Improved parsing and error-handling for certain field and metric retrieval flows.

* **Chores**
  * Version bumped to 0.1.267.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->