### PR TITLE
feat: add include-tests to Borrower resource child entity queries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = "Python SDK for AltScore"
 
 setup(
     name="altscore",
-    version="0.1.267",
+    version="0.1.268",
     description="Python SDK for AltScore. It provides a simple interface to the AltScore API.",
     package_dir={"": "src"},
     packages=find_packages(where="src"),

--- a/src/altscore/borrower_central/model/borrower.py
+++ b/src/altscore/borrower_central/model/borrower.py
@@ -24,7 +24,7 @@ from altscore.borrower_central.model.metrics import MetricSync, MetricAsync
 from altscore.common.http_errors import raise_for_status_improved, retry_on_401, retry_on_401_async
 from altscore.borrower_central.model.store_packages import PackageSync, PackageAsync
 from altscore.borrower_central.model.executions import ExecutionSync, ExecutionAsync
-from altscore.borrower_central.utils import clean_dict, convert_to_dash_case
+from altscore.borrower_central.utils import clean_dict, convert_to_dash_case, build_test_params
 
 from loguru import logger
 
@@ -212,7 +212,8 @@ class BorrowerBase:
 
     def _authorizations(
             self, borrower_id: str, sort_by: Optional[str] = None, key: Optional[str] = None,
-            per_page: Optional[int] = None, page: Optional[int] = None, sort_direction: Optional[str] = None
+            per_page: Optional[int] = None, page: Optional[int] = None, sort_direction: Optional[str] = None,
+            include_tests: bool = True, test_only: bool = False
     ) -> (str, dict):
         query = {
             "borrower-id": borrower_id,
@@ -222,11 +223,12 @@ class BorrowerBase:
             "page": page,
             "sort-direction": sort_direction
         }
-        return f"{self.base_url}/v1/authorizations", clean_dict(query)
+        return f"{self.base_url}/v1/authorizations", build_test_params(clean_dict(query), include_tests=include_tests, test_only=test_only)
 
     def _addresses(
             self, borrower_id: str, priority: Optional[int] = None, sort_by: Optional[str] = None,
-            per_page: Optional[int] = None, page: Optional[int] = None, sort_direction: Optional[str] = None
+            per_page: Optional[int] = None, page: Optional[int] = None, sort_direction: Optional[str] = None,
+            include_tests: bool = True, test_only: bool = False
     ) -> (str, dict):
         query = {
             "borrower-id": borrower_id,
@@ -236,12 +238,13 @@ class BorrowerBase:
             "page": page,
             "sort-direction": sort_direction
         }
-        return f"{self.base_url}/v1/addresses", clean_dict(query)
+        return f"{self.base_url}/v1/addresses", build_test_params(clean_dict(query), include_tests=include_tests, test_only=test_only)
 
     def _identities(
             self, borrower_id: str, priority: Optional[int] = None, sort_by: Optional[str] = None,
             key: Optional[str] = None, per_page: Optional[int] = None, page: Optional[int] = None,
-            sort_direction: Optional[str] = None
+            sort_direction: Optional[str] = None,
+            include_tests: bool = True, test_only: bool = False
     ) -> (str, dict):
         query = {
             "borrower-id": borrower_id,
@@ -252,12 +255,13 @@ class BorrowerBase:
             "page": page,
             "sort-direction": sort_direction
         }
-        return f"{self.base_url}/v1/identities", clean_dict(query)
+        return f"{self.base_url}/v1/identities", build_test_params(clean_dict(query), include_tests=include_tests, test_only=test_only)
 
     def _metrics(
             self, borrower_id: str, sort_by: Optional[str] = None,
             key: Optional[str] = None, per_page: Optional[int] = None, page: Optional[int] = None,
-            sort_direction: Optional[str] = None
+            sort_direction: Optional[str] = None,
+            include_tests: bool = True, test_only: bool = False
     ) -> (str, dict):
         query = {
             "borrower-id": borrower_id,
@@ -267,11 +271,12 @@ class BorrowerBase:
             "page": page,
             "sort-direction": sort_direction
         }
-        return f"{self.base_url}/v1/metrics", clean_dict(query)
+        return f"{self.base_url}/v1/metrics", build_test_params(clean_dict(query), include_tests=include_tests, test_only=test_only)
 
     def _documents(
             self, borrower_id: str, key: Optional[str] = None, sort_by: Optional[str] = None,
-            per_page: Optional[int] = None, page: Optional[int] = None, sort_direction: Optional[str] = None
+            per_page: Optional[int] = None, page: Optional[int] = None, sort_direction: Optional[str] = None,
+            include_tests: bool = True, test_only: bool = False
     ) -> (str, dict):
         query = {
             "borrower-id": borrower_id,
@@ -281,12 +286,13 @@ class BorrowerBase:
             "page": page,
             "sort-direction": sort_direction
         }
-        return f"{self.base_url}/v1/documents", clean_dict(query)
+        return f"{self.base_url}/v1/documents", build_test_params(clean_dict(query), include_tests=include_tests, test_only=test_only)
 
     def _points_of_contact(
             self, borrower_id: str, contact_method: Optional[str] = None, priority: Optional[int] = None,
             sort_by: Optional[str] = None, per_page: Optional[int] = None, page: Optional[int] = None,
-            sort_direction: Optional[str] = None
+            sort_direction: Optional[str] = None,
+            include_tests: bool = True, test_only: bool = False
     ) -> (str, dict):
         query = {
             "borrower-id": borrower_id,
@@ -297,12 +303,13 @@ class BorrowerBase:
             "page": page,
             "sort-direction": sort_direction
         }
-        return f"{self.base_url}/v1/points-of-contact", clean_dict(query)
+        return f"{self.base_url}/v1/points-of-contact", build_test_params(clean_dict(query), include_tests=include_tests, test_only=test_only)
 
     def _relationships(
             self, borrower_id: str, priority: Optional[int] = None, sort_by: Optional[str] = None,
             per_page: Optional[int] = None, page: Optional[int] = None, sort_direction: Optional[str] = None,
-            is_legal_representative: Optional[bool] = None
+            is_legal_representative: Optional[bool] = None,
+            include_tests: bool = True, test_only: bool = False
     ) -> (str, dict):
         query = {
             "borrower-id": borrower_id,
@@ -313,11 +320,12 @@ class BorrowerBase:
             "sort-direction": sort_direction,
             "is-legal-representative": is_legal_representative
         }
-        return f"{self.base_url}/v1/relationships", clean_dict(query)
+        return f"{self.base_url}/v1/relationships", build_test_params(clean_dict(query), include_tests=include_tests, test_only=test_only)
 
     def _borrower_fields(
             self, borrower_id: str, key: Optional[str] = None, sort_by: Optional[str] = None,
-            per_page: Optional[int] = None, page: Optional[int] = None, sort_direction: Optional[str] = None
+            per_page: Optional[int] = None, page: Optional[int] = None, sort_direction: Optional[str] = None,
+            include_tests: bool = True, test_only: bool = False
     ) -> (str, dict):
         query = {
             "borrower-id": borrower_id,
@@ -327,11 +335,12 @@ class BorrowerBase:
             "page": page,
             "sort-direction": sort_direction
         }
-        return f"{self.base_url}/v1/borrower-fields", clean_dict(query)
+        return f"{self.base_url}/v1/borrower-fields", build_test_params(clean_dict(query), include_tests=include_tests, test_only=test_only)
 
     def _packages(
             self, borrower_id: str, source_id: Optional[str] = None, sort_by: Optional[str] = None,
-            per_page: Optional[int] = None, page: Optional[int] = None, sort_direction: Optional[str] = None
+            per_page: Optional[int] = None, page: Optional[int] = None, sort_direction: Optional[str] = None,
+            include_tests: bool = True, test_only: bool = False
     ) -> (str, dict):
         query = {
             "borrower-id": borrower_id,
@@ -341,12 +350,13 @@ class BorrowerBase:
             "page": page,
             "sort-direction": sort_direction
         }
-        return f"{self.base_url}/v1/stores/packages", clean_dict(query)
+        return f"{self.base_url}/v1/stores/packages", build_test_params(clean_dict(query), include_tests=include_tests, test_only=test_only)
 
     def _executions(
             self, borrower_id: str, execution_id: Optional[str] = None, workflow_id: Optional[str] = None,
             sort_by: Optional[str] = None, per_page: Optional[int] = None, page: Optional[int] = None,
-            sort_direction: Optional[str] = None
+            sort_direction: Optional[str] = None,
+            include_tests: bool = True, test_only: bool = False
     ) -> (str, dict):
         query = {
             "billable-id": borrower_id,
@@ -357,13 +367,14 @@ class BorrowerBase:
             "page": page,
             "sort-direction": sort_direction
         }
-        return f"{self.base_url}/v1/executions", clean_dict(query)
+        return f"{self.base_url}/v1/executions", build_test_params(clean_dict(query), include_tests=include_tests, test_only=test_only)
 
     def _alerts(
             self, borrower_id: str, alert_id: Optional[str] = None, rule_id: Optional[str] = None,
             rule_code: Optional[str] = None, level: Optional[str] = None, reference_id: Optional[str] = None,
             is_acknowledged: Optional[bool] = None, sort_by: Optional[str] = None, per_page: Optional[int] = None,
-            page: Optional[int] = None, sort_direction: Optional[str] = None
+            page: Optional[int] = None, sort_direction: Optional[str] = None,
+            include_tests: bool = True, test_only: bool = False
     ) -> (str, dict):
         query = {
             "borrower-id": borrower_id,
@@ -378,7 +389,7 @@ class BorrowerBase:
             "page": page,
             "sort-direction": sort_direction
         }
-        return f"{self.base_url}/v1/alerts", clean_dict(query)
+        return f"{self.base_url}/v1/alerts", build_test_params(clean_dict(query), include_tests=include_tests, test_only=test_only)
 
 
 class BorrowersAsyncModule:
@@ -447,19 +458,21 @@ class BorrowersAsyncModule:
             raise_for_status_improved(response)
 
     @retry_on_401_async
-    async def find_one_by_identity(self, identity_key: str, identity_value: str):
+    async def find_one_by_identity(self, identity_key: str, identity_value: str,
+                                   include_tests: bool = True, test_only: bool = False):
         """
         Exact match by identity
         """
         async with httpx.AsyncClient(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "key": identity_key,
+                "value": identity_value,
+                "per-page": 1,
+                "page": 1
+            }, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 "/v1/identities",
-                params={
-                    "key": identity_key,
-                    "value": identity_value,
-                    "per-page": 1,
-                    "page": 1
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -691,19 +704,21 @@ class BorrowersSyncModule:
             raise_for_status_improved(response)
 
     @retry_on_401
-    def find_one_by_identity(self, identity_key: str, identity_value: str):
+    def find_one_by_identity(self, identity_key: str, identity_value: str,
+                             include_tests: bool = True, test_only: bool = False):
         """
         Exact match by identity
         """
         with httpx.Client(base_url=self.altscore_client._borrower_central_base_url) as client:
+            params = build_test_params({
+                "key": identity_key,
+                "value": identity_value,
+                "per-page": 1,
+                "page": 1
+            }, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 "/v1/identities",
-                params={
-                    "key": identity_key,
-                    "value": identity_value,
-                    "per-page": 1,
-                    "page": 1
-                },
+                params=params,
                 headers=self.build_headers(),
                 timeout=120,
             )
@@ -1033,9 +1048,10 @@ class BorrowerAsync(BorrowerBase):
             ) for document_data in data]
 
     @retry_on_401_async
-    async def get_identity_by_key(self, key: str) -> Optional[IdentityAsync]:
+    async def get_identity_by_key(self, key: str, include_tests: bool = True,
+                                  test_only: bool = False) -> Optional[IdentityAsync]:
         async with httpx.AsyncClient(base_url=self.base_url) as client:
-            url, query = self._identities(self.data.id, key=key)
+            url, query = self._identities(self.data.id, key=key, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 url,
                 headers=self._header_builder(),
@@ -1052,9 +1068,10 @@ class BorrowerAsync(BorrowerBase):
             )
 
     @retry_on_401_async
-    async def get_metric_by_key(self, key: str) -> Optional[MetricAsync]:
+    async def get_metric_by_key(self, key: str, include_tests: bool = True,
+                                test_only: bool = False) -> Optional[MetricAsync]:
         async with httpx.AsyncClient(base_url=self.base_url) as client:
-            url, query = self._metrics(self.data.id, key=key)
+            url, query = self._metrics(self.data.id, key=key, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 url,
                 headers=self._header_builder(),
@@ -1071,9 +1088,10 @@ class BorrowerAsync(BorrowerBase):
             )
 
     @retry_on_401_async
-    async def get_borrower_field_by_key(self, key: str) -> Optional[BorrowerFieldAsync]:
+    async def get_borrower_field_by_key(self, key: str, include_tests: bool = True,
+                                        test_only: bool = False) -> Optional[BorrowerFieldAsync]:
         async with httpx.AsyncClient(base_url=self.base_url) as client:
-            url, query = self._borrower_fields(self.data.id, key=key)
+            url, query = self._borrower_fields(self.data.id, key=key, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 url,
                 headers=self._header_builder(),
@@ -1090,9 +1108,10 @@ class BorrowerAsync(BorrowerBase):
             )
 
     @retry_on_401_async
-    async def get_document_by_key(self, key: str) -> Optional[DocumentAsync]:
+    async def get_document_by_key(self, key: str, include_tests: bool = True,
+                                  test_only: bool = False) -> Optional[DocumentAsync]:
         async with httpx.AsyncClient(base_url=self.base_url) as client:
-            url, query = self._documents(self.data.id, key=key)
+            url, query = self._documents(self.data.id, key=key, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 url,
                 headers=self._header_builder(),
@@ -1620,9 +1639,10 @@ class BorrowerSync(BorrowerBase):
             ) for document_data in data]
 
     @retry_on_401
-    def get_identity_by_key(self, key: str) -> Optional[IdentitySync]:
+    def get_identity_by_key(self, key: str, include_tests: bool = True,
+                            test_only: bool = False) -> Optional[IdentitySync]:
         with httpx.Client(base_url=self.base_url) as client:
-            url, query = self._identities(self.data.id, key=key)
+            url, query = self._identities(self.data.id, key=key, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 url,
                 headers=self._header_builder(),
@@ -1639,9 +1659,10 @@ class BorrowerSync(BorrowerBase):
             )
 
     @retry_on_401
-    def get_metric_by_key(self, key: str) -> Optional[MetricSync]:
+    def get_metric_by_key(self, key: str, include_tests: bool = True,
+                          test_only: bool = False) -> Optional[MetricSync]:
         with httpx.Client(base_url=self.base_url) as client:
-            url, query = self._metrics(self.data.id, key=key)
+            url, query = self._metrics(self.data.id, key=key, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 url,
                 headers=self._header_builder(),
@@ -1658,9 +1679,10 @@ class BorrowerSync(BorrowerBase):
             )
 
     @retry_on_401
-    def get_borrower_field_by_key(self, key: str) -> Optional[BorrowerFieldSync]:
+    def get_borrower_field_by_key(self, key: str, include_tests: bool = True,
+                                  test_only: bool = False) -> Optional[BorrowerFieldSync]:
         with httpx.Client(base_url=self.base_url) as client:
-            url, query = self._borrower_fields(self.data.id, key=key)
+            url, query = self._borrower_fields(self.data.id, key=key, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 url,
                 headers=self._header_builder(),
@@ -1677,9 +1699,10 @@ class BorrowerSync(BorrowerBase):
             )
 
     @retry_on_401
-    def get_document_by_key(self, key) -> Optional[DocumentSync]:
+    def get_document_by_key(self, key: str, include_tests: bool = True,
+                            test_only: bool = False) -> Optional[DocumentSync]:
         with httpx.Client(base_url=self.base_url) as client:
-            url, query = self._documents(self.data.id, key=key)
+            url, query = self._documents(self.data.id, key=key, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 url,
                 headers=self._header_builder(),


### PR DESCRIPTION
## Summary

- Follow-up to #162 -- the Borrower resource class was missed in the initial include-tests rollout.
- Adds `include_tests` (default `True`) / `test_only` (default `False`) to all 8 `_helper` methods on `BorrowerBase`: `_identities`, `_borrower_fields`, `_documents`, `_metrics`, `_addresses`, `_points_of_contact`, `_authorizations`, `_relationships`.
- Updates 4 explicit `get_*_by_key` methods (identity, metric, borrower_field, document) on both sync and async classes.
- The `get_*(**kwargs)` methods automatically inherit support via passthrough.
- Bumps version to 0.1.268.

## Test plan

- [ ] `borrower.get_borrower_fields()` returns fields for test borrowers
- [ ] `borrower.get_identities()` returns identities for test borrowers  
- [ ] `borrower.get_identity_by_key("some_key")` works for test borrowers
- [ ] `include_tests=False` excludes test entities

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added test data filtering options to borrower retrieval methods. You can now control whether test records are included or excluded when fetching identity, metric, borrower field, and document data by key.

* **Chores**
  * Bumped package version to 0.1.268.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->