### PR TITLE
fix: add explicit timeouts to Borrower metric accessors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = "Python SDK for AltScore"
 
 setup(
     name="altscore",
-    version="0.1.268",
+    version="0.1.269",
     description="Python SDK for AltScore. It provides a simple interface to the AltScore API.",
     package_dir={"": "src"},
     packages=find_packages(where="src"),

--- a/src/altscore/borrower_central/model/borrower.py
+++ b/src/altscore/borrower_central/model/borrower.py
@@ -1069,13 +1069,14 @@ class BorrowerAsync(BorrowerBase):
 
     @retry_on_401_async
     async def get_metric_by_key(self, key: str, include_tests: bool = True,
-                                test_only: bool = False) -> Optional[MetricAsync]:
+                                test_only: bool = False, timeout: int = 120) -> Optional[MetricAsync]:
         async with httpx.AsyncClient(base_url=self.base_url) as client:
             url, query = self._metrics(self.data.id, key=key, include_tests=include_tests, test_only=test_only)
             response = await client.get(
                 url,
                 headers=self._header_builder(),
-                params=query
+                params=query,
+                timeout=timeout
             )
             data = response.json()
             if len(data) == 0:
@@ -1197,13 +1198,14 @@ class BorrowerAsync(BorrowerBase):
             ) for borrower_field_data in data]
 
     @retry_on_401_async
-    async def get_metrics(self, **kwargs) -> List[MetricAsync]:
+    async def get_metrics(self, timeout: int = 120, **kwargs) -> List[MetricAsync]:
         async with httpx.AsyncClient(base_url=self.base_url) as client:
             url, query = self._metrics(self.data.id, **kwargs)
             response = await client.get(
                 url,
                 headers=self._header_builder(),
-                params=query
+                params=query,
+                timeout=timeout
             )
             data = response.json()
             return [MetricAsync(
@@ -1660,13 +1662,14 @@ class BorrowerSync(BorrowerBase):
 
     @retry_on_401
     def get_metric_by_key(self, key: str, include_tests: bool = True,
-                          test_only: bool = False) -> Optional[MetricSync]:
+                          test_only: bool = False, timeout: int = 120) -> Optional[MetricSync]:
         with httpx.Client(base_url=self.base_url) as client:
             url, query = self._metrics(self.data.id, key=key, include_tests=include_tests, test_only=test_only)
             response = client.get(
                 url,
                 headers=self._header_builder(),
-                params=query
+                params=query,
+                timeout=timeout
             )
             data = response.json()
             if len(data) == 0:
@@ -1788,13 +1791,14 @@ class BorrowerSync(BorrowerBase):
             ) for borrower_field_data in data]
 
     @retry_on_401
-    def get_metrics(self, **kwargs) -> List[MetricSync]:
+    def get_metrics(self, timeout: int = 120, **kwargs) -> List[MetricSync]:
         with httpx.Client(base_url=self.base_url) as client:
             url, query = self._metrics(self.data.id, **kwargs)
             response = client.get(
                 url,
                 headers=self._header_builder(),
-                params=query
+                params=query,
+                timeout=timeout
             )
             data = response.json()
             return [MetricSync(


### PR DESCRIPTION
## Problem

`get_metric_by_key` and `get_metrics` (sync and async) construct their httpx clients with no timeout, so they run on the **httpx default of 5.0s**.

BC's `/v1/metrics` is normally p50 20ms / p99 80ms, but tails to 5-7s when instances queue. Every one of those calls was aborted client-side at exactly 5.000s **even though BC went on to answer 200** — the server succeeded, the client gave up first.

This is the cause of the recurring `Error running workflow: The read operation timed out` alerts in the legacy v1 engine. Evidence: taking each slow `/v1/metrics` request's start time and adding 5.000s lands within 6-32ms of a workflow failure, in 7 of 8 observed cases.

Workflows that read many metric keys in a loop multiply the exposure by the number of keys — one tenant does 15 sequential calls per execution, giving roughly 22 failed executions/day.

## Change

Adds `timeout` to the four metric accessors, defaulting to **120s** — matching what the SDK already uses for this same endpoint in `metrics.py` (`find_borrower_metric_by_key` and `find_tenant_metric_by_key` both pass `timeout=120`).

Exposed as a parameter so callers can tighten or loosen it.

## Deliberately out of scope

- **The other 62 unguarded calls in `borrower.py`.** `generics.py` already codifies the wider convention (30s CRUD, 300s attachments); an audit shows 165 of 542 request calls SDK-wide still on the 5s default. Bringing those into line is a separate change.
- **`raise_for_status_improved`.** These methods call `response.json()` unchecked, which is a real latent bug, but adding error raising would turn today's silent-`None` behaviour into exceptions for callers across 14 repos. That is a behaviour change, not a timeout fix.

## Verification

Syntax-checked, and an AST audit confirms exactly 4 call sites moved from unguarded to guarded (169 to 165 SDK-wide; `borrower.py` 66 to 62) with no other site altered.

Backward compatibility tested against mocked transport, all passing:

| Check | Result |
|---|---|
| `get_metrics()` defaults to 120 | pass |
| `get_metrics(timeout=30)` honours override | pass |
| `get_metrics(per_page=200)` still reaches `_metrics` | pass |
| `get_metric_by_key()` defaults to 120 | pass |
| `get_metric_by_key()` still filters by key | pass |
| Legacy positional `get_metric_by_key(k, True, False)` | pass |
| `get_metric_by_key(timeout=5)` honours override | pass |
| `timeout` does not leak into `_metrics(**kwargs)` | pass |

That last one matters: `_metrics()` does not accept `timeout`, so leakage would be a hard `TypeError`. The explicit named parameter prevents it.

## Rollout note

Publishing is gated on `release: published`, not on merge — so this reaches no tenant until a release is cut. Version bumped to 0.1.269 per the convention in #164. Consumers pin `altscore>=0.1.263`, an unpinned floor, so once released it propagates to all tenants on their next image build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable request timeouts when retrieving individual borrower metrics or metric lists.
  - Requests now use a default timeout of 120 seconds, with the option to provide a custom value.

- **Chores**
  - Updated the package version to 0.1.269.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->