### PR TITLE
fix: lower metric accessor timeout from 120s to 30s

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ long_description = "Python SDK for AltScore"
 
 setup(
     name="altscore",
-    version="0.1.269",
+    version="0.1.270",
     description="Python SDK for AltScore. It provides a simple interface to the AltScore API.",
     package_dir={"": "src"},
     packages=find_packages(where="src"),

--- a/src/altscore/borrower_central/model/borrower.py
+++ b/src/altscore/borrower_central/model/borrower.py
@@ -1069,7 +1069,7 @@ class BorrowerAsync(BorrowerBase):
 
     @retry_on_401_async
     async def get_metric_by_key(self, key: str, include_tests: bool = True,
-                                test_only: bool = False, timeout: int = 120) -> Optional[MetricAsync]:
+                                test_only: bool = False, timeout: int = 30) -> Optional[MetricAsync]:
         async with httpx.AsyncClient(base_url=self.base_url) as client:
             url, query = self._metrics(self.data.id, key=key, include_tests=include_tests, test_only=test_only)
             response = await client.get(
@@ -1198,7 +1198,7 @@ class BorrowerAsync(BorrowerBase):
             ) for borrower_field_data in data]
 
     @retry_on_401_async
-    async def get_metrics(self, timeout: int = 120, **kwargs) -> List[MetricAsync]:
+    async def get_metrics(self, timeout: int = 30, **kwargs) -> List[MetricAsync]:
         async with httpx.AsyncClient(base_url=self.base_url) as client:
             url, query = self._metrics(self.data.id, **kwargs)
             response = await client.get(
@@ -1662,7 +1662,7 @@ class BorrowerSync(BorrowerBase):
 
     @retry_on_401
     def get_metric_by_key(self, key: str, include_tests: bool = True,
-                          test_only: bool = False, timeout: int = 120) -> Optional[MetricSync]:
+                          test_only: bool = False, timeout: int = 30) -> Optional[MetricSync]:
         with httpx.Client(base_url=self.base_url) as client:
             url, query = self._metrics(self.data.id, key=key, include_tests=include_tests, test_only=test_only)
             response = client.get(
@@ -1791,7 +1791,7 @@ class BorrowerSync(BorrowerBase):
             ) for borrower_field_data in data]
 
     @retry_on_401
-    def get_metrics(self, timeout: int = 120, **kwargs) -> List[MetricSync]:
+    def get_metrics(self, timeout: int = 30, **kwargs) -> List[MetricSync]:
         with httpx.Client(base_url=self.base_url) as client:
             url, query = self._metrics(self.data.id, **kwargs)
             response = client.get(


### PR DESCRIPTION
Follow-up to #165, which set the four Borrower metric accessors to `timeout=120`. 30s is the better default.

## Why 30 over 120

- **`GenericSyncModule.query` (`generics.py:382`) already uses 30 for this exact `/v1/metrics` endpoint** — and that is the path the batched tenant reads now go through, so 30 is already what runs in production for this read.
- `generics.py` codifies 30 for `retrieve`/`create`/`patch`/`delete`, and 30 is the most common value in the SDK (155 uses).
- The slowest observed BC response on this endpoint was **7.12s** against a p99 of 80ms. 30s is already ~4x headroom; 120s is ~17x.

120 is also actively worse under failure. The v1 engine runs Cloud Run with `concurrency=1` because it is not concurrency-safe, so a stuck call holds an instance's only slot for two minutes at 120s versus thirty seconds at 30s. Overly generous timeouts convert a fast failure into a capacity problem.

## On the justification in #165

#165 cited the eight pre-existing `timeout: int = 120` defaults in `borrower.py` as precedent. Those are on `create`/`patch`/`delete`/`retrieve` — which `generics.py` sets to **30**. They are local deviations from the convention, not evidence for it, so that was a weak argument. They are left untouched here to keep this change scoped.

## Scope and verification

Four default values and the version. Confirmed the 8 unrelated `timeout: int = 120` CRUD defaults are preserved and exactly 4 sites now read `timeout: int = 30`.

Backward-compat tests re-run against mocked transport, all passing:

| Check | Result |
|---|---|
| `get_metrics()` defaults to 30 | pass |
| `get_metrics(timeout=45)` honours override | pass |
| `get_metrics(per_page=200)` still reaches `_metrics` | pass |
| `get_metric_by_key()` defaults to 30 | pass |
| `get_metric_by_key()` still filters by key | pass |
| Legacy positional `get_metric_by_key(k, True, False)` | pass |
| `get_metric_by_key(timeout=5)` honours override | pass |
| `timeout` does not leak into `_metrics(**kwargs)` | pass |

The override test deliberately uses 45 rather than 30 so it cannot pass merely by matching the new default.

## Release

0.1.269 was merged but never released, so **no published version of the SDK has ever carried the 120s value**. Bumped to 0.1.270. Publishing is still gated on `release: published`, so this reaches no tenant until a release is cut.